### PR TITLE
Fix regex translations

### DIFF
--- a/Commands/Spoon2Twig/Helpers/SpoonRecipe.php
+++ b/Commands/Spoon2Twig/Helpers/SpoonRecipe.php
@@ -82,10 +82,10 @@ class SpoonRecipe implements Strategy
         $filedata = $this->pregReplaceSprintf('/{cache:(.*?)}/i', '{# cache(%s) #}', $filedata);
 
         // labels
-        $filedata = $this->pregReplaceSprintf('/lbl.(.*?)[!^|]/i', "'lbl.%s'|trans|", $filedata);
-        $filedata = $this->pregReplaceSprintf('/act.(.*?)[!^|]/i', "'act.%s'|trans|", $filedata);
-        $filedata = $this->pregReplaceSprintf('/msg.(.*?)[!^|]/i', "'msg.%s'|trans|", $filedata);
-        $filedata = $this->pregReplaceSprintf('/err.(.*?)[!^|]/i', "'err.%s'|trans|", $filedata);
+        $filedata = $this->pregReplaceSprintf('/lbl(.*?)[!^|]/i', "'lbl.%s'|trans|", $filedata);
+        $filedata = $this->pregReplaceSprintf('/act(.*?)[!^|]/i', "'act.%s'|trans|", $filedata);
+        $filedata = $this->pregReplaceSprintf('/msg(.*?)[!^|]/i', "'msg.%s'|trans|", $filedata);
+        $filedata = $this->pregReplaceSprintf('/err(.*?)[!^|]/i', "'err.%s'|trans|", $filedata);
         
         $filedata = $this->pregReplaceSprintf('/{{ lbl([\w]+) }}/i', "{{ 'lbl.%s'|trans }}", $filedata);
         $filedata = $this->pregReplaceSprintf('/{{ msg([\w]+) }}/i', "{{ 'msg.%s'|trans }}", $filedata);


### PR DESCRIPTION
I translated some twig strings, but the labels are missing their first letter
Example: http://d.pr/i/hwXW

When I remove the "." in the regex, it works perfectly.

Broken regex: https://regex101.com/r/aS2xD0/2 (doesnt select the first letter of the translation key)
Working regex: https://regex101.com/r/wX0tF6/1